### PR TITLE
Consolidate name logic in one place

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -50,5 +50,3 @@ replace (
 )
 
 replace github.com/operator-framework/operator-sdk => github.com/operator-framework/operator-sdk v0.11.0
-
-go 1.13

--- a/go.mod
+++ b/go.mod
@@ -50,3 +50,5 @@ replace (
 )
 
 replace github.com/operator-framework/operator-sdk => github.com/operator-framework/operator-sdk v0.11.0
+
+go 1.13

--- a/pkg/controller/opentelemetrycollector/reconcile.go
+++ b/pkg/controller/opentelemetrycollector/reconcile.go
@@ -146,3 +146,7 @@ func (r *ReconcileOpenTelemetryCollector) setControllerReference(ctx context.Con
 	instance := ctx.Value(opentelemetry.ContextInstance).(*v1alpha1.OpenTelemetryCollector)
 	return controllerutil.SetControllerReference(instance, object, r.scheme)
 }
+
+func resourceName(instanceName string) string {
+	return fmt.Sprintf("%s-collector", instanceName)
+}

--- a/pkg/controller/opentelemetrycollector/reconcile_configmap_test.go
+++ b/pkg/controller/opentelemetrycollector/reconcile_configmap_test.go
@@ -2,7 +2,6 @@ package opentelemetrycollector
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -61,7 +60,7 @@ func TestUpdateConfigMap(t *testing.T) {
 	reconciler.Reconcile(req)
 
 	// sanity check
-	name := fmt.Sprintf("%s-collector", instance.Name)
+	name := resourceName(instance.Name)
 	persisted := &corev1.ConfigMap{}
 	err := clients.client.Get(ctx, types.NamespacedName{Name: name, Namespace: instance.Namespace}, persisted)
 	assert.NoError(t, err)

--- a/pkg/controller/opentelemetrycollector/reconcile_daemonset.go
+++ b/pkg/controller/opentelemetrycollector/reconcile_daemonset.go
@@ -48,7 +48,7 @@ func daemonSets(ctx context.Context) []*appsv1.DaemonSet {
 func daemonSet(ctx context.Context) *appsv1.DaemonSet {
 	instance := ctx.Value(opentelemetry.ContextInstance).(*v1alpha1.OpenTelemetryCollector)
 	logger := ctx.Value(opentelemetry.ContextLogger).(logr.Logger)
-	name := fmt.Sprintf("%s-collector", instance.Name)
+	name := resourceName(instance.Name)
 
 	image := instance.Spec.Image
 	if len(image) == 0 {

--- a/pkg/controller/opentelemetrycollector/reconcile_daemonset_test.go
+++ b/pkg/controller/opentelemetrycollector/reconcile_daemonset_test.go
@@ -2,7 +2,6 @@ package opentelemetrycollector
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/spf13/viper"
@@ -152,7 +151,7 @@ func TestUpdateDaemonSet(t *testing.T) {
 	reconciler.Reconcile(req)
 
 	// sanity check
-	name := fmt.Sprintf("%s-collector", instance.Name)
+	name := resourceName(instance.Name)
 	persisted := &appsv1.DaemonSet{}
 	err := clients.client.Get(ctx, types.NamespacedName{Name: name, Namespace: instance.Namespace}, persisted)
 	assert.NoError(t, err)

--- a/pkg/controller/opentelemetrycollector/reconcile_deployment.go
+++ b/pkg/controller/opentelemetrycollector/reconcile_deployment.go
@@ -48,7 +48,7 @@ func deployments(ctx context.Context) []*appsv1.Deployment {
 func deployment(ctx context.Context) *appsv1.Deployment {
 	instance := ctx.Value(opentelemetry.ContextInstance).(*v1alpha1.OpenTelemetryCollector)
 	logger := ctx.Value(opentelemetry.ContextLogger).(logr.Logger)
-	name := fmt.Sprintf("%s-collector", instance.Name)
+	name := resourceName(instance.Name)
 
 	image := instance.Spec.Image
 	if len(image) == 0 {

--- a/pkg/controller/opentelemetrycollector/reconcile_deployment_test.go
+++ b/pkg/controller/opentelemetrycollector/reconcile_deployment_test.go
@@ -2,7 +2,6 @@ package opentelemetrycollector
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/spf13/viper"
@@ -145,7 +144,7 @@ func TestUpdateDeployment(t *testing.T) {
 	reconciler.Reconcile(req)
 
 	// sanity check
-	name := fmt.Sprintf("%s-collector", instance.Name)
+	name := resourceName(instance.Name)
 	persisted := &appsv1.Deployment{}
 	err := clients.client.Get(ctx, types.NamespacedName{Name: name, Namespace: instance.Namespace}, persisted)
 	assert.NoError(t, err)

--- a/pkg/controller/opentelemetrycollector/reconcile_service.go
+++ b/pkg/controller/opentelemetrycollector/reconcile_service.go
@@ -39,7 +39,7 @@ func (r *ReconcileOpenTelemetryCollector) reconcileService(ctx context.Context) 
 
 func service(ctx context.Context) *corev1.Service {
 	instance := ctx.Value(opentelemetry.ContextInstance).(*v1alpha1.OpenTelemetryCollector)
-	name := fmt.Sprintf("%s-collector", instance.Name)
+	name := resourceName(instance.Name)
 
 	labels := commonLabels(ctx)
 	labels["app.kubernetes.io/name"] = name

--- a/pkg/controller/opentelemetrycollector/reconcile_servicemonitor.go
+++ b/pkg/controller/opentelemetrycollector/reconcile_servicemonitor.go
@@ -42,7 +42,7 @@ func (r *ReconcileOpenTelemetryCollector) reconcileServiceMonitor(ctx context.Co
 
 func serviceMonitor(ctx context.Context) *monitoringv1.ServiceMonitor {
 	instance := ctx.Value(opentelemetry.ContextInstance).(*v1alpha1.OpenTelemetryCollector)
-	name := fmt.Sprintf("%s-collector", instance.Name)
+	name := resourceName(instance.Name)
 
 	labels := commonLabels(ctx)
 	labels["app.kubernetes.io/name"] = name

--- a/pkg/controller/opentelemetrycollector/reconcile_test.go
+++ b/pkg/controller/opentelemetrycollector/reconcile_test.go
@@ -155,3 +155,10 @@ func TestSetControllerReference(t *testing.T) {
 	assert.Equal(t, instance.TypeMeta.Kind, d.OwnerReferences[0].Kind)
 
 }
+
+func TestNameGeneration(t *testing.T) {
+	instanceName := "test"
+	expectedResourceName := "test-collector"
+
+	assert.Equal(t, expectedResourceName, resourceName(instanceName))
+}


### PR DESCRIPTION
A minor change to become familiar with the codebase.  Consolidates all "name" logic in the same place for clarity/ease of updating.

I had considered placing this functionality in the `labels.go` file and changing it to be something more generic.  Let me know if that's preferred.
